### PR TITLE
Update FieldFactory.php

### DIFF
--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -47,6 +47,7 @@ final class FieldFactory
         Types::DECIMAL => NumberField::class,
         Types::FLOAT => NumberField::class,
         Types::GUID => TextField::class,
+        'uuid' => TextField::class, // doctrine doesnt define such a type
         Types::INTEGER => IntegerField::class,
         Types::JSON => TextField::class,
         Types::OBJECT => TextField::class,


### PR DESCRIPTION
Hi,

If you have an entity such as

```php
#[ORM\Entity(repositoryClass: ProductRepository::class)]
class Product
{
    #[ORM\Id]
    #[ORM\GeneratedValue]
    #[ORM\Column(type: 'integer')]
    private $id;

    #[ORM\Column(type: 'uuid')]
    private UuidV6 $uuid;
    ...
```

And make a crud for it, when you want to edit such an entity you will get a `The Doctrine type of the "uuid" field is "uuid", which is not supported by EasyAdmin. For Doctrine's Custom Mapping Types have a look at EasyAdmin's field docs.` error.

Simplest fix is to map uuid to TextField. I don't see uuid in doctrine types so I hard write it.

Maybe it is related to #4125

Im not realy familiar with EA so my fix can be improved surely.